### PR TITLE
Added optional otp argument to account.login to pass in the 2FA code

### DIFF
--- a/api.py
+++ b/api.py
@@ -83,7 +83,7 @@ class ConfigNotFound(Exception):
         super().__init__(self.message)
 
 class account:
-    def login(email:str=None, password:str=None):
+    def login(email:str=None, password:str=None, otp:str=None):
         if (email == None or password == None) or (email == None and password == None):
             raise NoCredentials 
         else:
@@ -94,7 +94,7 @@ class account:
                 if login.text == "OK":
                     success = 1
                 elif login.text == """{"requiresCode":true}""":
-                    code = input("""Please enter 2FA Code: """)
+                    code = otp or input("""Please enter 2FA Code: """)
                     json = {"email":f"{email}","password":f"{password}","code":f"{code}"}
                     login = requests.post('https://api.nextdns.io/accounts/@login', headers=headers, json=json)
                 else:


### PR DESCRIPTION
Description of changes:
This pull request adds support for passing in the 2FA code via optional argument `otp` for `account.login` method. This allows you to run this unattended by dynamically generating the 2FA code using the OTP Secret Key using another library such as [pyotp](https://github.com/pyauth/pyotp).

Usage:
`account.login("example@example.com", "password123", "123456")` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.