### PR TITLE
Updated .gitignore to not ignore nextdnsapi package files: nextdnsapi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-
-build/lib/nextdnsapi/__init__.py
-build/lib/nextdnsapi/api.py
 dist/nextdnsapi-1.6.0-py3-none-any.whl
 nextdnsapi.egg-info/dependency_links.txt
 nextdnsapi.egg-info/PKG-INFO


### PR DESCRIPTION
Latest version 1.7.0 has a regression causing `ModuleNotFoundError` on `nextdnsapi` because the entire module package files are missing from the pypi package. I believe this is due to the updated `.gitignore` file but it's hard to tell because the entire source code of the pypi package is not present. 

Feel free to make any adjustments as necessary. 

Also, would you be willing to publish the entire pypi package source codes? It would make it easier for Contributors to test changes before submitting the PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.