### PR TITLE
Added Postman API collection, updated README.md, more to come! 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,23 @@
 
 #### Table Of Contents
 
-* [About the Project](./#about-the-project)
-* [Built With](./#built-with)
-* [Getting Started](./#getting-started)
-  * [Prerequisites](./#prerequisites)
-  * [Installation](./#installation)
-* [Usage](./#usage)
-* [Contributing](./#contributing)
-* [License](./#license)
-* [Authors](./#authors)
-* [Acknowledgements](./#acknowledgements)
+* [About the Project](#about-the-project)
+* [Built With](#built-with)
+  * [Prerequisites](#prerequisites)
+  * [Installation](#installation)
+* [Usage](#usage)
+  * [Account](#account)
+  * [Settings](#settings)
+  * [Security](#security)
+  * [Privacy](#privacy)
+  * [Parental](#parental)
+  * [Denylist](#denylist)
+  * [Allowlist](#allowlist)
+  * [Analytics](#analytics)
+* [Contributing](#contributing)
+* [License](#license)
+* [Authors](#authors)
+* [Acknowledgements](#acknowledgements)
 
 #### About The Project
 
@@ -43,7 +50,7 @@ Built using Python:
 
 * Requests library
 
-**Prerequisites**
+##### Prerequisites
 
 This is an example of how to list things you need to use the software and how to install them.
 
@@ -51,7 +58,7 @@ This is an example of how to list things you need to use the software and how to
 
 
 
-**Installation**
+##### Installation
 
 1. **```pip install nextdnsapi```**
 
@@ -75,9 +82,9 @@ from api import *
 
 Usage is very easy, so I won't bother to go into the intricacies of the library, but I will go over some basic info. This library closely imitates the website.
 
-**Account**
+##### Account
 
-For logging in using 2FA, see [2FA.md](https://github.com/rhijjawi/NextDNS-API/blob/main/2FA.md)
+For logging in using 2FA, see [2FA.md](2FA.md)
 ```python
 header = account.login("example@example.com", "password123")
 
@@ -95,7 +102,7 @@ account.month(header)
     Response: {"monthlyQueries":44065}
 ```
 
-**Settings**
+##### Settings
 
 ```python
 settings.listsettings(config,header):
@@ -144,7 +151,7 @@ settings.delete(config, header)
     Response: "{Config ID} deleted" if success, else ConfigNotFound
 ```
 
-**Security**
+##### Security
 
 ```python
 security.list(config, header)
@@ -205,7 +212,7 @@ security.removetld(tld, config, header)
     Response: "{tld} unblocked" if success, else ConfigNotFound
 ```
 
-**Privacy**
+##### Privacy
 
 ```python
 privacy.list(config, header)
@@ -230,7 +237,7 @@ privacy.unblocknative(native, config, header):
     Response: "OK" if success, else ConfigNotFound
 ```
 
-**Parental**
+##### Parental
 
 ```python
 parental.list(config, header)
@@ -279,7 +286,7 @@ parental.unblocksite(site, config, header)
     Response: "OK" if success, else ConfigNotFound
 ```
 
-**Denylist**
+##### Denylist
 
 ```python
 denylist.list(config, header)
@@ -296,7 +303,7 @@ denylist.unblockdomain(domain, config, header)
     Response: "OK" if success else ConfigNotFound
 ```
 
-**Allowlist**
+##### Allowlist
 
 ```python
 allowlist.list(config, header)
@@ -313,7 +320,7 @@ allowlist.remove(domain, config, header)
     Response: "OK" if success else ConfigNotFound
 ```
 
-**Analytics**
+##### Analytics
 
 ```python
 analytics.counter(config, header)
@@ -363,7 +370,7 @@ Contributions are what make the open source community such an amazing place to b
 * Create individual PR for each suggestion.
 * Please also read through the [Code Of Conduct](CODE\_OF\_CONDUCT.md) before posting your first idea as well.
 
-**Creating A Pull Request**
+##### Creating A Pull Request
 
 1. Fork the Project
 2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)

--- a/extras/postman/NextDNS API Testing.postman_collection.json
+++ b/extras/postman/NextDNS API Testing.postman_collection.json
@@ -1,0 +1,2838 @@
+{
+	"info": {
+		"_postman_id": "e28017f6-2442-41cd-a14e-dd94139168a0",
+		"name": "NextDNS API Testing",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Settings",
+			"item": [
+				{
+					"name": "List settings config",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/settings",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"settings"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Setup",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/setup",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"setup"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Clear logs",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/logs",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"logs"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Log domains (toggle)",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"logging_disable_query\":true}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/settings",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"settings"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Security",
+			"item": [
+				{
+					"name": "List security config",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Threat Intelligence Feeds",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"threatIntelligenceFeeds\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "AI-Driven Threat Detection",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"aiThreatDetection\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Google Safe Browsing",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"googleSafeBrowsing\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cryptojacking Protection",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"cryptojacking\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DNS Rebinding Protection",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"dnsRebinding\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "IDN Homograph Attacks Protection",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"homograph\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Typosquatting Protection",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"typosquatting\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DGA Protection",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"dga\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block NRDs",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"nrd\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block Parked Domains",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"parked\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block CSAM",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"csam\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/security",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"security"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Privacy",
+			"item": [
+				{
+					"name": "List privacy config",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/privacy",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"privacy"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block Disguised Trackers",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"blockDisguised\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/privacy",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"privacy"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block Native Trackers",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/privacy/natives/{{hex}}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"privacy",
+								"natives",
+								"{{hex}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unblock Native Trackers",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/privacy/natives/{{hex}}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"privacy",
+								"natives",
+								"{{hex}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block/Allow Affiliate Links",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"allowAffiliate\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/privacy",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"privacy"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Parental",
+			"item": [
+				{
+					"name": "Categories",
+					"item": [
+						{
+							"name": "Block Porn",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:706f726e",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:706f726e"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unblock Porn",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:706f726e",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:706f726e"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Block Gambling",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:67616d626c696e67",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:67616d626c696e67"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unblock Gambling",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:67616d626c696e67",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:67616d626c696e67"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Block Dating",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:646174696e67",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:646174696e67"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unblock Dating",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:646174696e67",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:646174696e67"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Block Piracy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:706972616379",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:706972616379"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unblock Piracy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:706972616379",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:706972616379"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Block Social Networks",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:736f6369616c2d6e6574776f726b73",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:736f6369616c2d6e6574776f726b73"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unblock Social Networks",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "sid",
+										"value": "{{nextdns_sid}}",
+										"type": "text"
+									},
+									{
+										"key": "pst",
+										"value": "{{nextdns_pst}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/categories/hex:736f6369616c2d6e6574776f726b73",
+									"protocol": "https",
+									"host": [
+										"api",
+										"nextdns",
+										"io"
+									],
+									"path": [
+										"configurations",
+										"{{uuid}}",
+										"parentalcontrol",
+										"categories",
+										"hex:736f6369616c2d6e6574776f726b73"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Safesearch Mode",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"safeSearch\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"parentalcontrol"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "YouTube Restricted Mode",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"youtubeRestrictedMode\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"parentalcontrol"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block Bypass Mode",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// var bool_values = [true, false];",
+									"pm.globals.set('value',  1-pm.globals.get('value'));",
+									"// console.log('DEBUG:', pm.globals.get('value'));",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"blockBypass\":{{value}}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"parentalcontrol"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block a Website",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/services/hex:{{sitename}}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"parentalcontrol",
+								"services",
+								"hex:{{sitename}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unblock a Website",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol/services/hex:{{sitename}}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"parentalcontrol",
+								"services",
+								"hex:{{sitename}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List parental config",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/parentalcontrol",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"parentalcontrol"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Deny List",
+			"item": [
+				{
+					"name": "Top Domains Blocked",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{nextdns_uuid}}/analytics/top_domains/blocked",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{nextdns_uuid}}",
+								"analytics",
+								"top_domains",
+								"blocked"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Block Domain",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/denylist/hex:{{hex}}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"denylist",
+								"hex:{{hex}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unblock Domain",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/denylist/hex:{{hex}}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"denylist",
+								"hex:{{hex}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List Deny config",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/denylist",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"denylist"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Allow List",
+			"item": [
+				{
+					"name": "Add Domain (allow)",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/allowlist/hex:{hex}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"allowlist",
+								"hex:{hex}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Remove Domain (disallow)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/allowlist/hex:{hex}",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"allowlist",
+								"hex:{hex}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List Allow config",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/allowlist",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"allowlist"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Analytics",
+			"item": [
+				{
+					"name": "Analytics",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/counters",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"counters"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Resolved Domains",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/top_domains/resolved",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"top_domains",
+								"resolved"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Blocked Domains",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/top_domains/blocked",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"top_domains",
+								"blocked"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Lists",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/top_lists",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"top_lists"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Devices",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/top_devices",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"top_devices"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Client IPs",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/top_client_ips",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"top_client_ips"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Root Domains",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/top_root_domains",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"top_root_domains"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GAFAM Dominance",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/gafam",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"gafam"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Top Countries",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{access_token}}",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "pst",
+								"value": "{{nextdns_pst}}",
+								"type": "text"
+							},
+							{
+								"key": "sid",
+								"value": "{{nextdns_sid}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://api.nextdns.io/configurations/{{uuid}}/analytics/traffic_destination_countries",
+							"protocol": "https",
+							"host": [
+								"api",
+								"nextdns",
+								"io"
+							],
+							"path": [
+								"configurations",
+								"{{uuid}}",
+								"analytics",
+								"traffic_destination_countries"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Request API Access Token",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.environment.set('nextdns_sid', pm.cookies.get('sid'));",
+							"pm.environment.set('nextdns_pst', pm.cookies.get('pst'));",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept-encoding": true,
+					"user-agent": true,
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Referer",
+						"value": "https://my.nextdns.io/",
+						"type": "text"
+					},
+					{
+						"key": "User-Agent",
+						"value": "NextDNS Prometheus Exporter",
+						"type": "text"
+					},
+					{
+						"key": "Connection",
+						"value": "keep-alive",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "text/html",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"email\": \"{{email}}\",\n    \"password\": \"{{password}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://api.nextdns.io/accounts/@login",
+					"protocol": "https",
+					"host": [
+						"api",
+						"nextdns",
+						"io"
+					],
+					"path": [
+						"accounts",
+						"@login"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "bearer"
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/extras/postman/NextDNS Variables.postman_environment.json
+++ b/extras/postman/NextDNS Variables.postman_environment.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"key": "uuid",
-			"value": "3db5b8",
+			"value": "5e6e5306",
 			"enabled": true
 		},
 		{

--- a/extras/postman/NextDNS Variables.postman_environment.json
+++ b/extras/postman/NextDNS Variables.postman_environment.json
@@ -1,0 +1,34 @@
+{
+	"id": "5104c02b-7c86-4366-aa24-712406b71993",
+	"name": "NextDNS Variables",
+	"values": [
+		{
+			"key": "email",
+			"value": "your-nextdns-login@domain.com",
+			"enabled": true
+		},
+		{
+			"key": "password",
+			"value": "YourS3ekretP4ssw0rd",
+			"enabled": true
+		},
+		{
+			"key": "uuid",
+			"value": "3db5b8",
+			"enabled": true
+		},
+		{
+			"key": "nextdns_sid",
+			"value": "{{nextdns_sid}}",
+			"enabled": true
+		},
+		{
+			"key": "nextdns_pst",
+			"value": "{{nextdns_pst}}",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2021-12-26T11:56:55.640Z",
+	"_postman_exported_using": "Postman/9.6.2"
+}


### PR DESCRIPTION
Just a small bit of contribution to your project. I stumbled onto your project this afternoon, after writing my own tools to inject a master blocklist of over 900k entries into NextDNS. 

I created a quick Postman API collection mapping to "most of" the API endpoints in NextDNS, with a few tiny exceptions which I'll work out later (adding/deleting/blocking domains from the hashmap). I also added a boolean toggle for flipping the switches on/off for those bool options. 

I'm going to be leveraging this heavily to create a Grafana dashboard of all of these analytics, which I'll also drop into `extras/grafana` when that's finished up. 

Great work, keep it up! 